### PR TITLE
MCP 4.1: Centralize CSV parsing; adopt in EaziPay and SDDirect; enable parse+validate

### DIFF
--- a/src/lib/fileType/csv.test.ts
+++ b/src/lib/fileType/csv.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseCsvLine, parseCsvContent } from './csv';
+
+interface ParsedRow { index: number; asLine: string; fields: string[] }
+interface ParseResult { rows: ParsedRow[] }
+
+describe('csv parser', () => {
+    it('parses simple comma-separated fields', () => {
+        const line = 'a,b,c,123';
+        const fields = parseCsvLine(line);
+        expect(fields).toEqual(['a', 'b', 'c', '123']);
+    });
+
+    it('handles quoted fields with commas', () => {
+        const line = '1,2,"Smith, John",4';
+        const fields = parseCsvLine(line);
+        expect(fields).toEqual(['1', '2', 'Smith, John', '4']);
+    });
+
+    it('handles escaped quotes inside quoted fields', () => {
+        const line = '1,"He said ""Hello""",3';
+        const fields = parseCsvLine(line);
+        expect(fields).toEqual(['1', 'He said "Hello"', '3']);
+    });
+
+    it('returns empty string for empty fields', () => {
+        const line = 'a,,c,';
+        const fields = parseCsvLine(line);
+        expect(fields).toEqual(['a', '', 'c', '']);
+    });
+
+    it('parseCsvContent returns rows with index/asLine/fields', () => {
+        const content = 'a,b,c\n1,2,3\n"Smith, Joe",5,6\n';
+        const res = parseCsvContent(content) as unknown as ParseResult;
+        expect(Array.isArray(res.rows)).toBe(true);
+        expect(res.rows[0]).toHaveProperty('index', 0);
+        expect(res.rows[0]).toHaveProperty('asLine', 'a,b,c');
+        expect(res.rows[2].fields).toEqual(['Smith, Joe', '5', '6']);
+    });
+});

--- a/src/lib/fileType/csv.ts
+++ b/src/lib/fileType/csv.ts
@@ -1,0 +1,40 @@
+// Lightweight CSV parsing utilities used by file-type adapters and fallback parser
+export function parseCsvLine(line: string): string[] {
+    const fields: string[] = [];
+    let cur = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (inQuotes) {
+            if (ch === '"') {
+                if (i + 1 < line.length && line[i + 1] === '"') {
+                    cur += '"';
+                    i++; // skip escaped quote
+                } else {
+                    inQuotes = false;
+                }
+            } else {
+                cur += ch;
+            }
+        } else {
+            if (ch === '"') {
+                inQuotes = true;
+            } else if (ch === ',') {
+                fields.push(cur);
+                cur = '';
+            } else {
+                cur += ch;
+            }
+        }
+    }
+    fields.push(cur);
+    return fields;
+}
+
+export function parseCsvContent(content: string): Record<string, unknown> {
+    const lines = content.split(/\r?\n/).filter((l) => l.length > 0);
+    const rows = lines.map((line, i) => ({ index: i, asLine: line, fields: parseCsvLine(line) }));
+    return { rows };
+}
+
+export default { parseCsvLine, parseCsvContent };

--- a/src/lib/fileType/parse.ts
+++ b/src/lib/fileType/parse.ts
@@ -1,4 +1,5 @@
 import { getFileTypeAdapter } from './factory';
+import { parseCsvContent } from './csv';
 
 export function parse(fileType: string, content: string): Record<string, unknown> {
     const adapter = getFileTypeAdapter(fileType) as unknown as { parse?: (c: string) => Record<string, unknown> };
@@ -6,8 +7,6 @@ export function parse(fileType: string, content: string): Record<string, unknown
         return adapter.parse!(content);
     }
 
-    // Fallback: split by newline into rows and attempt to split by comma
-    const lines = content.split(/\r?\n/).filter((l) => l.length > 0);
-    const rows = lines.map((line, i) => ({ index: i, asLine: line, fields: line.split(',') }));
-    return { rows };
+    // Fallback: use shared CSV parser which understands quoted fields
+    return parseCsvContent(content);
 }

--- a/src/services/fileParseAndValidate.test.ts
+++ b/src/services/fileParseAndValidate.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs/promises';
+import { parseAndValidate } from './fileParseAndValidate';
+import { eaziPayAdapter } from '../lib/fileType/eazipay';
+import type { PreviewParams } from '../lib/fileType/adapter';
+
+// Helper to write a temporary file
+async function writeTemp(content: string): Promise<string> {
+  const tmp = `./output/test-${Date.now()}-${Math.random().toString(16).slice(2)}.csv`;
+  await fs.mkdir('./output', { recursive: true });
+  await fs.writeFile(tmp, content, 'utf8');
+  return tmp;
+}
+
+type ParseResultStrict = { summary: { total: number; valid: number; invalid: number }; rows: Array<Record<string, unknown>> };
+
+describe('file.parseAndValidate - EaziPay', () => {
+  it('valid file yields all rows valid', async () => {
+  const params: PreviewParams = { numberOfRows: 5, hasInvalidRows: false, dateFormat: 'YYYY-MM-DD', fileType: 'EaziPay', sun: 'DEFAULT' };
+  const rows = eaziPayAdapter.buildPreviewRows(params);
+  const content = eaziPayAdapter.serialize(rows, params);
+    const path = await writeTemp(content);
+
+    const res = await parseAndValidate({ filePath: path, fileType: 'EaziPay' });
+    expect(res && typeof res === 'object').toBe(true);
+  const parsed = res as ParseResultStrict;
+  expect(parsed.summary.total).toBe(5);
+  expect(parsed.summary.valid).toBe(5);
+  expect(parsed.summary.invalid).toBe(0);
+  });
+
+  it('invalid rows are reported', async () => {
+  const params: PreviewParams = { numberOfRows: 6, hasInvalidRows: true, dateFormat: 'YYYY-MM-DD', fileType: 'EaziPay', sun: 'DEFAULT' };
+  const rows = eaziPayAdapter.buildPreviewRows(params);
+  const content = eaziPayAdapter.serialize(rows, params);
+    const path = await writeTemp(content);
+
+    const res = await parseAndValidate({ filePath: path, fileType: 'EaziPay' });
+  const parsed = res as ParseResultStrict;
+  const summary = parsed.summary;
+  expect(summary.total).toBe(6);
+  // at least one invalid row expected
+  expect(summary.invalid).toBeGreaterThan(0);
+  });
+
+  it('handles empty file gracefully', async () => {
+    const path = await writeTemp('');
+    const res = await parseAndValidate({ filePath: path, fileType: 'EaziPay' });
+  const parsed = res as ParseResultStrict;
+  const summary = parsed.summary;
+  expect(summary.total).toBe(0);
+  expect(summary.valid).toBe(0);
+  expect(summary.invalid).toBe(0);
+  });
+});


### PR DESCRIPTION
Summary\n- Shared CSV parser (quoted fields, escaped quotes) in src/lib/fileType/csv.ts\n- Fallback parser now uses shared CSV parser\n- EaziPay adapter imports shared parser; deterministic invalid-row placement\n- SDDirect adapter adds parse(content) using shared parser\n- parseAndValidate service now validates each row via existing validators\n- New CSV unit tests\n\nRisk/impact\n- Backward-compatible; adapters preserve public API\n- Parsing now consistent across adapters and fallback\n\nQuality gates\n- Lint/build/tests passing locally\n\nLinked issues\n- MCP-4.1 CSV parsing refactor