### PR TITLE
security: validate preview inputs for SDDirect (Backlog #15)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -86,4 +86,24 @@ describe('API: new endpoints', () => {
             expect(res.body.success).toBe(false);
         });
     });
+
+    describe('Backlog #15: preview input validation', () => {
+        it('returns 400 for SDDirect valid-row when numberOfRows is invalid', async () => {
+            const res = await request(app)
+                .post('/api/TESTSUN/SDDirect/valid-row')
+                .send({ numberOfRows: 0 });
+            expect(res.status).toBe(400);
+            expect(res.body.success).toBe(false);
+            expect(String(res.body.error)).toContain('numberOfRows');
+        });
+
+        it('returns 400 for SDDirect invalid-row when dateFormat is invalid', async () => {
+            const res = await request(app)
+                .post('/api/TESTSUN/SDDirect/invalid-row')
+                .send({ numberOfRows: 1, dateFormat: 'YYYY/MM/DD' });
+            expect(res.status).toBe(400);
+            expect(res.body.success).toBe(false);
+            expect(String(res.body.error)).toContain('dateFormat');
+        });
+    });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,10 @@ import type {
     SuccessResponse,
 } from './lib/types';
 import { logError, logRequest, logResponse } from './lib/utils/logger';
-import { validateAndNormalizeGenerateRequest } from './lib/validators/requestValidator';
+import {
+    validateAndNormalizeGenerateRequest,
+    validateRowPreviewRequest,
+} from './lib/validators/requestValidator';
 
 const app = express();
 app.use(express.json());
@@ -100,6 +103,13 @@ app.post('/api/:sun/:filetype/valid-row', async (req: Request, res: Response) =>
     try {
         const { sun, filetype } = req.params as { sun: string; filetype: string };
         const body = req.body as RowPreviewRequest;
+        // Validate preview request
+        const previewErrors = validateRowPreviewRequest(body);
+        if (previewErrors.length > 0) {
+            const response: ErrorResponse = { success: false, error: previewErrors.join('; ') };
+            logResponse(res, response);
+            return res.status(400).json(response);
+        }
         const internal = toInternalRequest(filetype, body, sun);
         const numberOfRows = internal.numberOfRows ?? 15;
         const rows = await buildRowsResponse(filetype, internal, numberOfRows, false);
@@ -121,6 +131,13 @@ app.post('/api/:sun/:filetype/invalid-row', async (req: Request, res: Response) 
     try {
         const { sun, filetype } = req.params as { sun: string; filetype: string };
         const body = req.body as RowPreviewRequest;
+        // Validate preview request
+        const previewErrors = validateRowPreviewRequest(body);
+        if (previewErrors.length > 0) {
+            const response: ErrorResponse = { success: false, error: previewErrors.join('; ') };
+            logResponse(res, response);
+            return res.status(400).json(response);
+        }
         const internal = toInternalRequest(filetype, body, sun);
         const numberOfRows = internal.numberOfRows ?? 15;
         const rows = await buildRowsResponse(filetype, internal, numberOfRows, true);


### PR DESCRIPTION
Implements input validation for /valid-row and /invalid-row preview endpoints and adds integration tests for SDDirect.\n\n- Rejects invalid numberOfRows (<=0 or non-integer) with 400\n- Validates dateFormat against supported formats\n- Tests cover both valid-row and invalid-row endpoints\n\nQuality gates: lint/build/tests pass locally.